### PR TITLE
Replace python3 getcode() with status attr

### DIFF
--- a/src/si/amp.py
+++ b/src/si/amp.py
@@ -57,7 +57,7 @@ class Amp(object):
             conn.request('GET', url)
             response = conn.getresponse()
             if response.status != 200:
-                raise Exception('bad response code %s: needs to be 200' % response.getcode())
+                raise Exception('bad response code %s: needs to be 200' % response.status)
             text = response.read()
             text = text.decode('utf-8')
             if text != 'Key is known':


### PR DESCRIPTION
#### Problem

`getcode()` is a method on Python 3's `HTTPResponse`, and is not available in Python 2.

#### Solution

Use `status`