### PR TITLE
Updating to use the requests library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+certifi==2019.3.9
+chardet==3.0.4
+idna==2.8
+requests==2.21.0
+urllib3==1.24.1

--- a/src/si/amp.py
+++ b/src/si/amp.py
@@ -39,10 +39,10 @@ class Amp(object):
 
         for amp_agent in self._amp_agents:
             https, host, port = Amp.parse_agent(amp_agent)
-            conn = smart_conn.SmartConn(self._logger, https, host, port, self._timeout, self._reconnect_timeout)
+            conn = smart_conn.SmartConn(self._logger, https, host, port, self._timeout)
             url = '/test/update_from_spa/' + self._project_key + "?session_life_time=%s" % self._session_lifetime
             response = conn.request('GET', url)
-            if response != 'Key is known':
+            if response.text != 'Key is known':
                 raise AmpError('got response text %s. Needs to be "Key is known"' % response)
             self.conns.append(conn)
 

--- a/src/si/amp.py
+++ b/src/si/amp.py
@@ -4,8 +4,8 @@ Top level module used to create an amp object, which represents a project.
 
 import logging
 
-import smart_conn
-import session
+from . import smart_conn
+from . import session
 
 
 class AmpError(Exception):

--- a/src/si/no_op_amp.py
+++ b/src/si/no_op_amp.py
@@ -1,6 +1,6 @@
 import logging
 
-import session
+from . import session
 
 
 class NoOpAmp(object):

--- a/src/si/session.py
+++ b/src/si/session.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 """
 This module implements the Session object
 """

--- a/src/si/session.py
+++ b/src/si/session.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 """
 This module implements the Session object
 """
@@ -206,7 +207,7 @@ class Session(object):
         headers = {'Content-type': 'application/json'}
         url = "%s/%s/observeV2" % (self.amp.api_path, self.amp.key)
         response = conn.request("POST", url, data, headers)
-        return json.loads(response)
+        return response.json()
 
     def _send_decide_event(self, conn, context_name, decision_name, candidates, with_context, properties, **options):
         """
@@ -229,7 +230,7 @@ class Session(object):
         else:
             url = '%s/%s/decideV2' % (self.amp.api_path, self.amp.key)
         response = conn.request('POST', url, data, headers)
-        return json.loads(response)
+        return response.json()
 
     def atomic_next_index(self):
         """

--- a/src/si/smart_conn.py
+++ b/src/si/smart_conn.py
@@ -15,7 +15,7 @@ class SmartConn:
         self._request_session = requests.Session()
 
     def _build_url(self, path):
-        return '{}/{}:{}'.format(self._base_url, path, self._port)
+        return '{}:{}/{}'.format(self._base_url, self._port, path)
 
     def request(self, method, path, data=None, headers=None):
         return self._request_session.request(method, self._build_url(path), data=data, headers=headers,

--- a/src/si/smart_conn.py
+++ b/src/si/smart_conn.py
@@ -1,84 +1,22 @@
 import logging
-import socket
-import sys
-import time
+import requests
 
-import amp
-
-if sys.version_info[0] == 3:
-    import http.client as univ_http_client
-else:
-    import httplib as univ_http_client
-
-DEFAULT_RECONNECT_TIMOUT = 10
-DEFAULT_SOCKET_TIMOUT = 10
+DEFAULT_SOCKET_TIMEOUT = 10
 
 
 class SmartConn:
-    def __init__(self, logger, https, host, port, timeout=DEFAULT_SOCKET_TIMOUT,
-                 reconnect_timeout=DEFAULT_RECONNECT_TIMOUT):
+    def __init__(self, logger, https, host, port, timeout=DEFAULT_SOCKET_TIMEOUT):
         logging.basicConfig()
         self._logger = logger or logging.getLogger('amp')
         self._https, self._host, self._port = https, host, port
-        self._reconnect_timeout = reconnect_timeout
         self._socket_timeout = timeout
-        self._c()
-        if self._conn is None:
-            raise amp.AmpError("Can't connect to %s:%s" % (host, port))
+        protocol = 'https' if https else 'http'
+        self._base_url = '{}://{}'.format(protocol, host)
+        self._request_session = requests.Session()
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.close()
-
-    def _c(self):
-        if self._https:
-            self._conn = univ_http_client.HTTPSConnection(self._host, self._port, self._socket_timeout)
-        else:
-            self._conn = univ_http_client.HTTPConnection(self._host, self._port, self._socket_timeout)
-        try:
-            self._conn.connect()
-        except socket.error:
-            self._logger.warning("Can't connect to %s:%d" % (self._host, self._port))
-            self._conn.close()
-            self._disconnect_time = time.time()
-            self._conn = None
-
-    def _r(self, method, path, data, headers):
-        try:
-            self._conn.request(method, path, data, headers)
-        except socket.error:  # For python 2.7
-            self._conn.close()
-            self._disconnect_time = time.time()
-            self._conn = None
-            raise Exception("The connection to %s:%d has dropped" % (self._host, self._port))
-        except ConnectionError:  # For python 3.7
-            self._logger.warning("The connection to %s:%d has dropped" % (self._host, self._port))
-            self._conn.close()
-            self._disconnect_time = time.time()
-            self._conn = None
-            raise Exception("The connection to %s:%d has dropped" % (self._host, self._port))
-        response = self._conn.getresponse()
-        text = response.read()
-        text = text.decode('utf-8')
-        if response.status != 200:
-            raise amp.AmpError('%s %s:%s/%s failed with status %d: %s' %
-                               (method, self._host, self._port, path, response.status, text))
-        return text
+    def _build_url(self, path):
+        return '{}/{}:{}'.format(self._base_url, path, self._port)
 
     def request(self, method, path, data=None, headers=None):
-        if headers is None:
-            headers = {}
-        if self._conn is not None:
-            return self._r(method, path, data, headers)
-        if time.time() - self._disconnect_time < self._reconnect_timeout:
-            raise Exception("The connection to %s:%d is down" % (self._host, self._port))
-        self._c()
-        if self._conn is None:
-            raise Exception("The connection to %s:%d is down" % (self._host, self._port))
-        return self._r(method, path, data, headers)
-
-    def close(self):
-        if self._conn is not None:
-            self._conn.close()
+        return self._request_session.request(method, self._build_url(path), data=data, headers=headers,
+                                             timeout=self._socket_timeout)


### PR DESCRIPTION
We removed manual connection management features in favor of using the requests library. This enables nice things like connection pooling and python2/3 interoperability.

Here, we also ran some pylint fixes.